### PR TITLE
Add `.break()` and fall-through support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,16 @@ const result = new EnhancedSwitch(value)
 
 - [Class `EnhancedSwitch<T, U>`](#class-enhancedswitcht-u)
   - [`new EnhancedSwitch(expression: T)`](#new-enhancedswitchexpression-t)
+  - [`enhancedSwitch.allowFallthrough`](#enhancedswitchallowfallthrough)
+  - [`enhancedSwitch.break()`](#enhancedswitchbreak)
   - [`enhancedSwitch.case(valueN: T | T[], code: U)`](#enhancedswitchcasevaluen-t--t-code-u)
   - [`enhancedSwitch.case(valueN: T | T[], code: (s: EnhancedSwitch<T, U>) => U | void)`](#enhancedswitchcasevaluen-t--t-code-s-enhancedswitcht-u--u--void)
   - [`enhancedSwitch.default(code: U)`](#enhancedswitchdefaultcode-u)
   - [`enhancedSwitch.default(code: (s: EnhancedSwitch<T, U>) => U | void)`](#enhancedswitchdefaultcode-s-enhancedswitcht-u--u--void)
   - [`enhancedSwitch.default(code: U, returnvalueN: true)`](#enhancedswitchdefaultcode-u-returnvaluen-true)
   - [`enhancedSwitch.default(code: (s: EnhancedSwitch<T, U>) => U | void, returnvalueN: true)`](#enhancedswitchdefaultcode-s-enhancedswitcht-u--u--void-returnvaluen-true)
+  - [`enhancedSwitch.expression`](#enhancedswitchexpression)
+  - [`enhancedSwitch.hasConcluded`](#enhancedswitchhasconcluded)
   - [`enhancedSwitch.value`](#enhancedswitchvalue)
 
 ## Class `EnhancedSwitch<T, U>`
@@ -89,6 +93,18 @@ Create a new EnhancedSwitch
 | Parameter    | Type | Description                                                       |
 |--------------|------|-------------------------------------------------------------------|
 | `expression` | `T`  | An expression whose result is matched against each `case` clause. |
+
+### `enhancedSwitch.allowFallthrough`
+
+Whether to allow fallthrough. If true, the switch will continue to execute `case` clauses after the first match until a `break` is encountered. Defaults to false.
+
+Type: [`boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean). Read-only.
+
+### `enhancedSwitch.break()`
+
+Prevent further execution of any subsequent `case` or `default` clauses.
+
+Returns: `this` ([`EnhancedSwitch<T, U>`](#class-enhancedswitcht-u))
 
 ### `enhancedSwitch.case(valueN: T | T[], code: U)`
 
@@ -153,6 +169,18 @@ A `default` clause; if provided, this clause is executed if the value of `expres
 | `returnvalueN` | `true`                                   | If true, the provided value is returned instead of the switch instance. |
 
 Returns: `U`
+
+### `enhancedSwitch.expression`
+
+An expression whose result is matched against each `case` clause.
+
+Type: `T`. Read-only.
+
+### `enhancedSwitch.hasConcluded`
+
+Whether the switch statement has concluded (no further `case` or `default` will be executed). A switch can be concluded by calling [`enhancedSwitch.break()`](#enhancedswitchbreak) or constructing with `allowFallthrough` set to false.
+
+Type: [`boolean`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean). Read-only.
 
 ### `enhancedSwitch.value`
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -35,14 +35,14 @@ describe("EnhancedSwitch", () => {
     });
 
     it("should correctly handle case clause with function returning undefined", () => {
-        assert.strictEqual(
-            new EnhancedSwitch<number, string>(2)
-                .case(1, "One")
-                .case(2, () => undefined)
-                .default("Default")
-                .value,
-            "Default"
-        );
+        let a;
+        new EnhancedSwitch<number, string>(2)
+            .case(1, "One")
+            .case(2, () => {
+                a = 2;
+            })
+            .default("Default")
+        assert.strictEqual(a, 2);
     });
 
     it("should correctly handle case clause with an array of values", () => {
@@ -64,6 +64,31 @@ describe("EnhancedSwitch", () => {
                 .value,
             "Three from function with 3"
         );
+    });
+
+    it("should correctly handle fall-through cases without breaking", () => {
+        let i = 0;
+        new EnhancedSwitch(2, true)
+            .case(1, () => assert.fail())
+            .case(2, () => ++i)
+            .case(3, () => assert.fail())
+            .case(2, () => ++i)
+            .case(2, () => ++i)
+            .default(() => ++i);
+        assert.strictEqual(i, 4);
+    });
+
+    it("should correct conclude switch with fall-through cases when break is called", () => {
+        let i = 0;
+        new EnhancedSwitch(2, true)
+            .case(1, () => assert.fail())
+            .case(2, () => ++i)
+            .case(3, () => assert.fail())
+            .case(2, () => ++i)
+            .break()
+            .case(2, () => ++i)
+            .default(() => ++i);
+        assert.strictEqual(i, 2);
     });
 
     it("should correctly execute a default clause", () => {
@@ -118,6 +143,16 @@ describe("EnhancedSwitch", () => {
                 .default(() => undefined)
                 .value;
         }, TypeError, "Switch has no result.");
+    });
+
+    it("should return correct value when evaluating default when already concluded", () => {
+        assert.strictEqual(
+            new EnhancedSwitch<number, string>(2)
+                .case(1, "One")
+                .case(2, "Two")
+                .default("Default", true),
+            "Two"
+        );
     });
 
     it("should throw an error when no case matches and no default clause is provided", () => {


### PR DESCRIPTION
Fixes an issue that forces fall-through with no-return switches.

Adds an option to enable fall-through for the switch by passing `allowFallthrough` as true in the constructor.

Adds a `.break()` method.